### PR TITLE
chore: Enhance debug logs

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -58,8 +58,8 @@ impl Drop for FileGuard {
 
 async fn start_daemon() -> anyhow::Result<()> {
     env_logger::Builder::new()
-        .format(|buf, record| writeln!(buf, "{}", record.args()))
-        .filter_level(log::LevelFilter::Debug)
+        .format(|buf, record| write!(buf, "{}", record.args()))
+        .parse_default_env()
         .init();
 
     print_info("Starting daemon...");

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -10,7 +10,7 @@ pub fn print_error(msg: &str) {
 }
 
 pub fn print_debug(msg: &str) {
-    debug!("[{}] {}", log_prefix(), msg);
+    debug!("[{}] DEBUG {}", log_prefix(), msg);
 }
 
 fn log_prefix() -> impl std::fmt::Display {


### PR DESCRIPTION
1. respect `RUST_LOG`
2. no newline