### PR TITLE
fix: Better pgrep matching for codex and gemini

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -331,7 +331,7 @@ async fn get_agent_pids() -> anyhow::Result<Vec<(Agent, String)>> {
             .args(["-x", "codex"])
             .output(),
         tokio::process::Command::new("pgrep")
-            .args(["-f", "bin/gemini"])
+            .args(["-f", r"(^|/)gemini($| )"])
             .output(),
     );
     let pids = String::from_utf8_lossy(&output_claude?.stdout)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -328,10 +328,10 @@ async fn get_agent_pids() -> anyhow::Result<Vec<(Agent, String)>> {
             .args(["-x", "claude"])
             .output(),
         tokio::process::Command::new("pgrep")
-            .args(["-f", "codex"])
+            .args(["-x", "codex"])
             .output(),
         tokio::process::Command::new("pgrep")
-            .args(["-f", "gemini"])
+            .args(["-f", "bin/gemini"])
             .output(),
     );
     let pids = String::from_utf8_lossy(&output_claude?.stdout)


### PR DESCRIPTION
# Summary

`-f` with raw string is effectively doing substring matching.

# Test Plan

played around a bit