### PR TITLE
chore: Convert it to session-based

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,13 +1,11 @@
 pub fn get_pid_file_path() -> String {
-    std::env::var("TMUX_BOTDOMO_PID_PATH").unwrap_or_else(|_| {
-        // TODO: XDG_RUNTIME_DIR?
-        let session_id = get_tmux_session_id();
-        format!(
-            "/tmp/tmux-botdomo-{}-{}.pid",
-            std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
-            session_id,
-        )
-    })
+    // TODO: XDG_RUNTIME_DIR?
+    let session_id = get_tmux_session_id();
+    format!(
+        "/tmp/tmux-botdomo-{}-{}.pid",
+        std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
+        session_id,
+    )
 }
 
 pub fn get_socket_path() -> String {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,6 +1,6 @@
 pub fn get_pid_file_path() -> String {
-    // TODO: XDG_RUNTIME_DIR?
     let session_id = get_tmux_session_id();
+    // TODO: XDG_RUNTIME_DIR?
     format!(
         "/tmp/tmux-botdomo-{}-{}.pid",
         std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
@@ -9,14 +9,12 @@ pub fn get_pid_file_path() -> String {
 }
 
 pub fn get_socket_path() -> String {
-    std::env::var("TMUX_BOTDOMO_SOCK_PATH").unwrap_or_else(|_| {
-        let session_id = get_tmux_session_id();
-        format!(
-            "/tmp/tmux-botdomo-{}-{}.sock",
-            std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
-            session_id,
-        )
-    })
+    let session_id = get_tmux_session_id();
+    std::env::var("TMUX_BOTDOMO_SOCK_PATH").unwrap_or(format!(
+        "/tmp/tmux-botdomo-{}-{}.sock",
+        std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
+        session_id,
+    ))
 }
 
 pub fn get_tmux_session_id() -> String {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,22 +1,28 @@
-pub const TMUX_BOTDOMO_SOCK_PATH: &str = "/tmp/tmux-botdomo.sock";
-
 pub fn get_pid_file_path() -> String {
+    let session_id = get_tmux_session_id();
     // TODO: XDG_RUNTIME_DIR?
     format!(
-        "/tmp/tmux-botdomo-{}.pid",
-        std::env::var("USER").unwrap_or_else(|_| "unknown".to_string())
+        "/tmp/tmux-botdomo-{}-{}.pid",
+        std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
+        session_id,
     )
 }
 
 pub fn get_socket_path() -> String {
-    std::env::var("TMUX_BOTDOMO_SOCK_PATH").unwrap_or(TMUX_BOTDOMO_SOCK_PATH.to_string())
+    let session_id = get_tmux_session_id();
+    std::env::var("TMUX_BOTDOMO_SOCK_PATH").unwrap_or(format!(
+        "/tmp/tmux-botdomo-{}-{}.sock",
+        std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
+        session_id,
+    ))
 }
 
-pub fn get_tmux_session_id() -> Option<String> {
+pub fn get_tmux_session_id() -> String {
     std::process::Command::new("tmux")
         .args(["display-message", "-p", "#{session_id}"])
         .output()
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())
         .map(|s| s.trim().to_string())
+        .unwrap_or("none".to_string())
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,11 +1,13 @@
 pub fn get_pid_file_path() -> String {
-    // TODO: XDG_RUNTIME_DIR?
-    let session_id = get_tmux_session_id();
-    format!(
-        "/tmp/tmux-botdomo-{}-{}.pid",
-        std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
-        session_id,
-    )
+    std::env::var("TMUX_BOTDOMO_PID_PATH").unwrap_or_else(|_| {
+        // TODO: XDG_RUNTIME_DIR?
+        let session_id = get_tmux_session_id();
+        format!(
+            "/tmp/tmux-botdomo-{}-{}.pid",
+            std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
+            session_id,
+        )
+    })
 }
 
 pub fn get_socket_path() -> String {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -17,6 +17,12 @@ pub fn get_socket_path() -> String {
     ))
 }
 
+#[cfg(feature = "test-mode")]
+pub fn get_tmux_session_id() -> String {
+    "test".to_string()
+}
+
+#[cfg(not(feature = "test-mode"))]
 pub fn get_tmux_session_id() -> String {
     std::process::Command::new("tmux")
         .args(["display-message", "-p", "#{session_id}"])

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,6 +1,6 @@
 pub fn get_pid_file_path() -> String {
-    let session_id = get_tmux_session_id();
     // TODO: XDG_RUNTIME_DIR?
+    let session_id = get_tmux_session_id();
     format!(
         "/tmp/tmux-botdomo-{}-{}.pid",
         std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
@@ -9,12 +9,14 @@ pub fn get_pid_file_path() -> String {
 }
 
 pub fn get_socket_path() -> String {
-    let session_id = get_tmux_session_id();
-    std::env::var("TMUX_BOTDOMO_SOCK_PATH").unwrap_or(format!(
-        "/tmp/tmux-botdomo-{}-{}.sock",
-        std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
-        session_id,
-    ))
+    std::env::var("TMUX_BOTDOMO_SOCK_PATH").unwrap_or_else(|_| {
+        let session_id = get_tmux_session_id();
+        format!(
+            "/tmp/tmux-botdomo-{}-{}.sock",
+            std::env::var("USER").unwrap_or_else(|_| "unknown".to_string()),
+            session_id,
+        )
+    })
 }
 
 pub fn get_tmux_session_id() -> String {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,10 +6,12 @@ use tokio::time::sleep;
 async fn test_daemon_cil_communication() -> anyhow::Result<()> {
     let test_id = std::process::id();
     let socket_path = format!("/tmp/tmux-botdomo-test-{test_id}.sock");
+    let pid_path = format!("/tmp/tmux-botdomo-test-{test_id}.pid");
 
     let mut daemon = Command::new("cargo")
         .args(["run", "--features", "test-mode", "--bin", "tbdmd", "start"])
         .env("TMUX_BOTDOMO_SOCK_PATH", &socket_path)
+        .env("TMUX_BOTDOMO_PID_PATH", &pid_path)
         .spawn()?;
 
     sleep(Duration::from_millis(500)).await;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,12 +6,10 @@ use tokio::time::sleep;
 async fn test_daemon_cil_communication() -> anyhow::Result<()> {
     let test_id = std::process::id();
     let socket_path = format!("/tmp/tmux-botdomo-test-{test_id}.sock");
-    let pid_path = format!("/tmp/tmux-botdomo-test-{test_id}.pid");
 
     let mut daemon = Command::new("cargo")
         .args(["run", "--features", "test-mode", "--bin", "tbdmd", "start"])
         .env("TMUX_BOTDOMO_SOCK_PATH", &socket_path)
-        .env("TMUX_BOTDOMO_PID_PATH", &pid_path)
         .spawn()?;
 
     sleep(Duration::from_millis(500)).await;


### PR DESCRIPTION
# Summary

tmux hooks actually doesn't support per-"instance", instead they only support up to per-session (`session-created`). Therefore we have to adapt from the daemon side, hence this PR.

# Test Plan

launched two session and observed the logs for agent detection.
