### PR TITLE
chore: Default to follow for send command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ struct Args {
 
 #[derive(Subcommand)]
 enum Command {
-    Send { 
+    Send {
         context: String,
 
         #[arg(long)]
@@ -29,12 +29,16 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     match args.command {
-        Command::Send { context , no_follow } => {
+        Command::Send { context, no_follow } => {
             let cwd = std::env::current_dir()
                 .ok()
                 .map(|s| s.to_string_lossy().to_string());
             if let Some(cwd) = cwd {
-                let request = CliRequest::Send { cwd, context, no_follow };
+                let request = CliRequest::Send {
+                    cwd,
+                    context,
+                    no_follow,
+                };
                 send_to_daemon(request).await?;
             } else {
                 eprintln!("Failed to obtain cwd for the client.");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,12 @@ struct Args {
 
 #[derive(Subcommand)]
 enum Command {
-    Send { context: String },
+    Send { 
+        context: String,
+
+        #[arg(long)]
+        no_follow: bool,
+    },
     Status,
     Version,
 }
@@ -24,12 +29,12 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     match args.command {
-        Command::Send { context } => {
+        Command::Send { context , no_follow } => {
             let cwd = std::env::current_dir()
                 .ok()
                 .map(|s| s.to_string_lossy().to_string());
             if let Some(cwd) = cwd {
-                let request = CliRequest::Send { cwd, context };
+                let request = CliRequest::Send { cwd, context, no_follow };
                 send_to_daemon(request).await?;
             } else {
                 eprintln!("Failed to obtain cwd for the client.");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -151,7 +151,11 @@ async fn handle_connection(
     let buffer = read_from_stream(&mut stream).await?;
     print_debug(&format!("Received {buffer}"));
     let response = match serde_json::from_str(&buffer) {
-        Ok(CliRequest::Send { cwd, context , no_follow}) => {
+        Ok(CliRequest::Send {
+            cwd,
+            context,
+            no_follow,
+        }) => {
             print_info(&format!("Received cwd: {cwd:?} context: {context:?}"));
             handle_send(session_info, &cwd, &context, no_follow).await?
         }
@@ -238,7 +242,11 @@ async fn handle_send(
 }
 
 #[cfg(feature = "test-mode")]
-async fn relay_to_tmux(_pane_target: &str, _context: &str, _should_not_follow: bool) -> anyhow::Result<Output> {
+async fn relay_to_tmux(
+    _pane_target: &str,
+    _context: &str,
+    _should_not_follow: bool,
+) -> anyhow::Result<Output> {
     println!("Running in test mode. No messages is actually relayed.");
     Ok(Output {
         status: std::process::ExitStatus::default(),
@@ -248,7 +256,11 @@ async fn relay_to_tmux(_pane_target: &str, _context: &str, _should_not_follow: b
 }
 
 #[cfg(not(feature = "test-mode"))]
-async fn relay_to_tmux(pane_target: &str, context: &str, should_not_follow: bool) -> anyhow::Result<Output> {
+async fn relay_to_tmux(
+    pane_target: &str,
+    context: &str,
+    should_not_follow: bool,
+) -> anyhow::Result<Output> {
     let mut args = Vec::new();
     if !should_not_follow {
         args.extend(["select-pane", "-t", pane_target, ";"]);

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,7 +5,7 @@ use tokio::net::UnixStream;
 
 #[derive(Serialize, Deserialize)]
 pub enum CliRequest {
-    Send { cwd: String, context: String },
+    Send { cwd: String, context: String, no_follow: bool },
     Status,
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -5,7 +5,11 @@ use tokio::net::UnixStream;
 
 #[derive(Serialize, Deserialize)]
 pub enum CliRequest {
-    Send { cwd: String, context: String, no_follow: bool },
+    Send {
+        cwd: String,
+        context: String,
+        no_follow: bool,
+    },
     Status,
 }
 


### PR DESCRIPTION
# Summary

The pane focus should follow the send command to the agent pane by default. Also added an option to not follow.

# Test Plan

Played it around
